### PR TITLE
exclude the `swift2` branch from travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: objective-c
 osx_image: xcode6.4
+# blacklist
+branches:
+  except:
+    - swift2
 script:
     - xcodebuild -project ModelRocket.xcodeproj -scheme ModelRocket -sdk iphonesimulator8.4 test


### PR DESCRIPTION
...until travis supports xcode7 (still in beta as of this commit)
