### PR TITLE
Ask ModelRocket's failable init to return nil when JSON is nil.

### DIFF
--- a/ModelRocket/ModelRocket.swift
+++ b/ModelRocket/ModelRocket.swift
@@ -62,26 +62,33 @@ public class ModelRocket: NSObject, NSCoding {
     
     public required convenience init?(strictJSON: JSON) {
         self.init()
-
-        if strictJSON == nil {
-            return nil
-        }
         
         var valid = true
         
         var debugString = "Initializing object of type: \(self.dynamicType)"
+
+        if strictJSON == nil {
+            #if DEBUG
+                debugString += "\n\tInitialization failed due to null JSON"
+            #else
+                break
+            #endif
+            valid = false
+        }
         
-        for map in JSONMappings {
-            let validObject = map.fromJSON(strictJSON)
-            
-            if map.required && !validObject {
-                valid = false
+        if valid {
+            for map in JSONMappings {
+                let validObject = map.fromJSON(strictJSON)
                 
-                #if DEBUG
-                    debugString += "\n\tProperty failed for key: \(map.key), type: \(map.type)"
-                #else
-                    break
-                #endif
+                if map.required && !validObject {
+                    valid = false
+                    
+                    #if DEBUG
+                        debugString += "\n\tProperty failed for key: \(map.key), type: \(map.type)"
+                    #else
+                        break
+                    #endif
+                }
             }
         }
         

--- a/ModelRocket/ModelRocket.swift
+++ b/ModelRocket/ModelRocket.swift
@@ -62,6 +62,10 @@ public class ModelRocket: NSObject, NSCoding {
     
     public required convenience init?(strictJSON: JSON) {
         self.init()
+
+        if strictJSON == nil {
+            return nil
+        }
         
         var valid = true
         


### PR DESCRIPTION
I've tried just about every other permutation of `ModelRocket(strictJSON:)` that I could, and maybe I'm using it wrong, but I've got a dilemma around optional JSON nodes that map to other `ModelRocket` subclasses. Basically, the child property object gets initialized, even if there is no node for it.

I've got two models: a `Document` and a `Category`.

``` swift
class Document: ModelRocket {
    var category: Category? {
        return _category.value
    }
    private let _category = Property<Category>(key: "category")

    var categoryIdentifier: String? {
        return category?.identifier
    }
}

class Category: ModelRocket {
    var identifier: String! {
        return _identifier.value!
    }
    private let _identifier = Property<String>(key: "id")
}
```

A `Document`'s `Category` is optional, but a `Category`'s `identifier` is required (provided the category exists).

If I pass in JSON like this…

``` json
[
  { "document": {
      "category": {
          "id": "1-category"
      }
    },
  }
  { "document": { } }
]
```

For what it's worth, these is my `JSONTransformable` extensions for each.

``` swift
extension Document: JSONTransformable {
    typealias T = Document

    static func fromJSON(json: JSON) -> Document? {
        return Document(strictJSON: json)
    }

    func toJSON() -> AnyObject {
        return self.json().dictionary
    }
}

extension Category: JSONTransformable {
    typealias T = Category

    static func fromJSON(json: JSON) -> Category? {
        return Category(strictJSON: json)
    }

    func toJSON() -> AnyObject {
        return self.json().dictionary
    }
}
```

The first `Document` gets created with a `Category` just fine, and the document's `categoryIdentifier` property is a-ok. The second `Document` gets created, but when I hit `categoryIdentifier`, I expect to get `nil` back; instead, I get a `fatal error: unexpectedly found nil while unwrapping an Optional value` crash, inside of the `Category`'s `identifier` property. The `Category` object should never have been created if there was no `"category"` node in the JSON.

This pull request slightly modifies the `strictJSON`-based fail-able initializer so that if the `json` passed in is `nil`, then the object returned is also `nil`. It's only after I make this change that everything initializes (or doesn't) like I expect it to.
