### PR TITLE
Add ability to check for `null` in JSON with `is NSNull`.

### DIFF
--- a/ModelRocket/JSON.swift
+++ b/ModelRocket/JSON.swift
@@ -285,6 +285,14 @@ extension Dictionary {
     }
 }
 
+// MARK: - NSNull
+
+extension JSON {
+    public var isNull: Bool {
+        return object is NSNull
+    }
+}
+
 // MARK: - Equatable
 
 extension JSON: Equatable {}

--- a/ModelRocket/JSON.swift
+++ b/ModelRocket/JSON.swift
@@ -70,8 +70,16 @@ public struct JSON {
         }
     }
     
-    public var isNil: Bool {
+    @available(*, deprecated=1.2, message="Use !hasKey instead.") public var isNil: Bool {
         return (object == nil)
+    }
+    
+    public var hasKey: Bool {
+        return object != nil
+    }
+    
+    public var hasValue: Bool {
+        return !(object is NSNull)
     }
 }
 
@@ -288,9 +296,6 @@ extension Dictionary {
 // MARK: - NSNull
 
 extension JSON {
-    public var isNull: Bool {
-        return object is NSNull
-    }
 }
 
 // MARK: - Equatable

--- a/ModelRocketTests/JSONTests.swift
+++ b/ModelRocketTests/JSONTests.swift
@@ -55,7 +55,7 @@ class JSONTests: XCTestCase {
         
         // No data
         let emptyJSON = JSON(data: nil)
-        XCTAssertTrue(emptyJSON.isNil, "JSON not nil")
+        XCTAssertFalse(emptyJSON.hasKey, "JSON not nil")
         
         // String
         XCTAssertEqual(vehicleJSON["make"].stringValue, "BMW")
@@ -443,7 +443,7 @@ class JSONTests: XCTestCase {
         let jsonData = NSData(contentsOfFile: jsonPath!)
         let json = JSON(data: jsonData)
         
-        XCTAssertTrue(json["driver"].isNull)
+        XCTAssertFalse(json["driver"].hasValue)
     }
     
     // MARK: - Dictionary

--- a/ModelRocketTests/JSONTests.swift
+++ b/ModelRocketTests/JSONTests.swift
@@ -436,6 +436,16 @@ class JSONTests: XCTestCase {
         XCTAssertEqual(json["array"][0].intValue, 1)
     }
     
+    // MARK: - NSNull (from loaded data)
+    
+    func testNSNull() {
+        let jsonPath = NSBundle(forClass: self.dynamicType).pathForResource("Tests", ofType: "json")
+        let jsonData = NSData(contentsOfFile: jsonPath!)
+        let json = JSON(data: jsonData)
+        
+        XCTAssertTrue(json["driver"].isNull)
+    }
+    
     // MARK: - Dictionary
     
     func testDictionaryLiteralConvertible() {

--- a/ModelRocketTests/Tests.json
+++ b/ModelRocketTests/Tests.json
@@ -6,7 +6,7 @@
 	"number_of_doors" : 4,
 	"zero_to_sixty_time" : 4.7,
 	"nav_system_standard" : true,
-    "driver": null,
+	"driver": null,
 	"manufacturer" : {
 		"company_name" : "Bayerische Motoren Werke AG",
 		"headquarters" : "Munich, Bavaria, Germany",

--- a/ModelRocketTests/Tests.json
+++ b/ModelRocketTests/Tests.json
@@ -6,6 +6,7 @@
 	"number_of_doors" : 4,
 	"zero_to_sixty_time" : 4.7,
 	"nav_system_standard" : true,
+    "driver": null,
 	"manufacturer" : {
 		"company_name" : "Bayerische Motoren Werke AG",
 		"headquarters" : "Munich, Bavaria, Germany",


### PR DESCRIPTION
The inability for us to check if a key exists, but is `null`, in the JSON was kind of a bummer, so I wrote this up.

Note that this is different for checking if a key doesn't exist, which is where you'd use `json["not_a_key"].isNil`. Instead, if you have an object in the JSON as such…

``` json
{
    "can_be_null": null
}
```

Then you check if that object is null using the change in this PR by asking

``` swift
json["can_be_null"].isNull // returns true
json["can_be_null"].isNil // returns false, because the key is there, but is not nil; it's null
```

This PR comes complete with unit test addition!
