### PR TITLE
Add check for null value using hasValue; rename isNil to hasKey.

### DIFF
--- a/ModelRocket/JSON.swift
+++ b/ModelRocket/JSON.swift
@@ -79,7 +79,7 @@ public struct JSON {
     }
     
     public var hasValue: Bool {
-        return !(object is NSNull)
+        return object != nil && !(object is NSNull)
     }
 }
 

--- a/ModelRocket/JSON.swift
+++ b/ModelRocket/JSON.swift
@@ -70,8 +70,16 @@ public struct JSON {
         }
     }
     
-    public var isNil: Bool {
+    @available(*, deprecated=1.2, message="Use !hasKey instead.") public var isNil: Bool {
         return (object == nil)
+    }
+    
+    public var hasKey: Bool {
+        return object != nil
+    }
+    
+    public var hasValue: Bool {
+        return !(object is NSNull)
     }
 }
 
@@ -283,6 +291,11 @@ extension Dictionary {
             self[key] = value
         }
     }
+}
+
+// MARK: - NSNull
+
+extension JSON {
 }
 
 // MARK: - Equatable

--- a/ModelRocket/JSON.swift
+++ b/ModelRocket/JSON.swift
@@ -293,11 +293,6 @@ extension Dictionary {
     }
 }
 
-// MARK: - NSNull
-
-extension JSON {
-}
-
 // MARK: - Equatable
 
 extension JSON: Equatable {}

--- a/ModelRocketTests/JSONTests.swift
+++ b/ModelRocketTests/JSONTests.swift
@@ -55,8 +55,8 @@ class JSONTests: XCTestCase {
         
         // No data
         let emptyJSON = JSON(data: nil)
-        XCTAssertFalse(emptyJSON.hasKey, "JSON not nil")
-        XCTAssertFalse(emptyJSON.hasValue, "JSON does not have value")
+        XCTAssertFalse(emptyJSON.hasKey, "JSON is not nil")
+        XCTAssertFalse(emptyJSON.hasValue, "JSON has a value")
         
         // String
         XCTAssertEqual(vehicleJSON["make"].stringValue, "BMW")

--- a/ModelRocketTests/JSONTests.swift
+++ b/ModelRocketTests/JSONTests.swift
@@ -55,7 +55,7 @@ class JSONTests: XCTestCase {
         
         // No data
         let emptyJSON = JSON(data: nil)
-        XCTAssertTrue(emptyJSON.isNil, "JSON not nil")
+        XCTAssertFalse(emptyJSON.hasKey, "JSON not nil")
         
         // String
         XCTAssertEqual(vehicleJSON["make"].stringValue, "BMW")
@@ -434,6 +434,16 @@ class JSONTests: XCTestCase {
         XCTAssertEqual(json["array"].startIndex, 0)
         XCTAssertEqual(json["array"].endIndex, 5)
         XCTAssertEqual(json["array"][0].intValue, 1)
+    }
+    
+    // MARK: - NSNull (from loaded data)
+    
+    func testNSNull() {
+        let jsonPath = NSBundle(forClass: self.dynamicType).pathForResource("Tests", ofType: "json")
+        let jsonData = NSData(contentsOfFile: jsonPath!)
+        let json = JSON(data: jsonData)
+        
+        XCTAssertFalse(json["driver"].hasValue)
     }
     
     // MARK: - Dictionary

--- a/ModelRocketTests/JSONTests.swift
+++ b/ModelRocketTests/JSONTests.swift
@@ -56,6 +56,7 @@ class JSONTests: XCTestCase {
         // No data
         let emptyJSON = JSON(data: nil)
         XCTAssertFalse(emptyJSON.hasKey, "JSON not nil")
+        XCTAssertFalse(emptyJSON.hasValue, "JSON does not have value")
         
         // String
         XCTAssertEqual(vehicleJSON["make"].stringValue, "BMW")

--- a/ModelRocketTests/Tests.json
+++ b/ModelRocketTests/Tests.json
@@ -6,6 +6,7 @@
 	"number_of_doors" : 4,
 	"zero_to_sixty_time" : 4.7,
 	"nav_system_standard" : true,
+	"driver": null,
 	"manufacturer" : {
 		"company_name" : "Bayerische Motoren Werke AG",
 		"headquarters" : "Munich, Bavaria, Germany",


### PR DESCRIPTION
This pull request supersedes #8 and more or less continues the discussion from there.

The ability for us to check if a key exists is written as `!isNil`, but no check currently exists for when the key is present, but the resulting value is `nil` (when deserialized using `NSJSONSerialization`, these are brought into the object as `NSNull`).

What this PR does is allow `JSON` to respond to `.hasKey` and `.hasValue` (the former being a newly-revised version of `isNil`, the latter checking for `object is NSNull`). So now, if you have an object in the JSON as such…

``` json
{
    "can_be_null": null
}
```

Then you check if that object is null using the change in this PR by asking

``` swift
json["can_be_null"].hasKey // returns true
json["can_be_null"].hasValue // returns false

// Additionally...
json["not_a_key"].hasKey // returns false
json["not_a_key"].hasValue // returns false
```

This PR comes complete with unit test addition!
