### PR TITLE
Extended JSON to RawRepresentable protocol

### DIFF
--- a/ModelRocketTests/JSONTests.swift
+++ b/ModelRocketTests/JSONTests.swift
@@ -481,4 +481,23 @@ class JSONTests: XCTestCase {
         XCTAssertEqual(json["dictionary"]["string2"].stringValue, "String 2")
         XCTAssertEqual(json["dictionary"]["string3"].stringValue, "String 3")
     }
+    
+    // MARK: - Raw (from loaded data)
+    
+    func testRaw() {
+        let jsonPath = NSBundle(forClass: self.dynamicType).pathForResource("Tests", ofType: "json")
+        let jsonData = NSData(contentsOfFile: jsonPath!)
+        let json = JSON(data: jsonData)
+        
+        XCTAssertFalse(json["model"].rawValue is NSNull)
+        XCTAssertTrue(json["driver"].rawValue is NSNull)
+
+        do {
+            let data = try json.rawData()
+            
+            XCTAssertNotNil(data)
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
 }

--- a/Sources/JSON.swift
+++ b/Sources/JSON.swift
@@ -24,7 +24,7 @@ import Foundation
 
 public struct JSON {
     
-    private(set) var object: AnyObject?
+    private var object: AnyObject?
     
     public init() {
         self.object = nil
@@ -299,16 +299,14 @@ extension Dictionary {
 
 extension JSON: RawRepresentable {
     
-    enum JSONDataError: ErrorType {
-        case ObjectMissing
-        case InvalidJSONObject
+    enum DataError: ErrorType {
+        case MissingObject
+        case InvalidObject
     }
     
     public init?(rawValue: AnyObject) {
         guard NSJSONSerialization.isValidJSONObject(rawValue) else {
-            self.init()
-            
-            return
+            return nil
         }
         
         self.init(rawValue)
@@ -318,13 +316,13 @@ extension JSON: RawRepresentable {
         return self.object ?? NSNull()
     }
     
-    public func rawData(options: NSJSONWritingOptions = NSJSONWritingOptions(rawValue: 0)) throws -> NSData {
+    public func rawData(options: NSJSONWritingOptions = []) throws -> NSData {
         guard let object = object else {
-            throw JSONDataError.ObjectMissing
+            throw DataError.MissingObject
         }
         
         guard NSJSONSerialization.isValidJSONObject(object) else {
-            throw JSONDataError.InvalidJSONObject
+            throw DataError.InvalidObject
         }
         
         return try NSJSONSerialization.dataWithJSONObject(object, options: options)

--- a/Sources/JSON.swift
+++ b/Sources/JSON.swift
@@ -295,6 +295,42 @@ extension Dictionary {
     }
 }
 
+// MARK: - Raw
+
+extension JSON: RawRepresentable {
+    
+    enum JSONDataError: ErrorType {
+        case ObjectMissing
+        case InvalidJSONObject
+    }
+    
+    public init?(rawValue: AnyObject) {
+        guard NSJSONSerialization.isValidJSONObject(rawValue) else {
+            self.init()
+            
+            return
+        }
+        
+        self.init(rawValue)
+    }
+    
+    public var rawValue: AnyObject {
+        return self.object ?? NSNull()
+    }
+    
+    public func rawData(options: NSJSONWritingOptions = NSJSONWritingOptions(rawValue: 0)) throws -> NSData {
+        guard let object = object else {
+            throw JSONDataError.ObjectMissing
+        }
+        
+        guard NSJSONSerialization.isValidJSONObject(object) else {
+            throw JSONDataError.InvalidJSONObject
+        }
+        
+        return try NSJSONSerialization.dataWithJSONObject(object, options: options)
+    }
+}
+
 // MARK: - Equatable
 
 extension JSON: Equatable {}

--- a/Sources/JSON.swift
+++ b/Sources/JSON.swift
@@ -24,7 +24,7 @@ import Foundation
 
 public struct JSON {
     
-    private var object: AnyObject?
+    private(set) var object: AnyObject?
     
     public init() {
         self.object = nil


### PR DESCRIPTION
This provides anyone using this library as a simple JSON parser the ability grab the object property directly from a JSON instance. The setter is still private.
